### PR TITLE
Resolve column name ambiguity issue

### DIFF
--- a/lib/arrangeable.rb
+++ b/lib/arrangeable.rb
@@ -30,7 +30,7 @@ module Arrangeable
           key = key[1..-1]
         end
         next unless arrangeable_fields.include?(key)
-        key + order
+        "#{self.table_name}.#{key}" + order
       end.compact.join(', ')
     end
   end

--- a/lib/arrangeable.rb
+++ b/lib/arrangeable.rb
@@ -30,7 +30,7 @@ module Arrangeable
           key = key[1..-1]
         end
         next unless arrangeable_fields.include?(key)
-        "#{self.table_name}.#{key}" + order
+        "#{self.table_name}.#{key} #{order}"
       end.compact.join(', ')
     end
   end


### PR DESCRIPTION
When you try to order by 'id' for example while you have joined with another table that has an 'id' column you will face a column name ambiguity error. In this PR we just add a full identifier for the column to resolve such errors.